### PR TITLE
Psicorps guild updates

### DIFF
--- a/chars/droptable/aliases.tin
+++ b/chars/droptable/aliases.tin
@@ -36,6 +36,18 @@
   fold reality;
 };
 
+#NOP --- Botting configurations;
+
+#alias {.pre_fight_check} {
+  #var _bb 0;
+  #var _dm 0;
+};
+
+#alias .mob_kill_action {
+  exa $mobname;
+  kill $mobname;
+};
+
 #NOP --- Psicorps power configurations;
 
 #alias {defense} {

--- a/chars/droptable/aliases.tin
+++ b/chars/droptable/aliases.tin
@@ -38,34 +38,49 @@
 
 #NOP --- Psicorps power configurations;
 
-#alias {base} {
-  #var psiwield 0;
-  #var psiwield_1 hammer;
+#alias {defense} {
+  #var psiwield 1;
+  #var psiwield_1 shard;
+  #var psiwield_2 shard 2;
+  #var use_expertise 0;
   #var combat {};
 
   #nop -- Defense buffs;
 
-  #var combat[Iv] 1;
-  #var combat[Vr] 1;
+  #var combat[ab] 1;
+  #var combat[Cp] 0;
+  #var combat[Eb] 0;
+  #var combat[IB] 1;
+  #var combat[IV] 1;
+  #var combat[Ib] 1;
+  #var combat[Iv] 0;
   #var combat[Vg] 1;
+  #var combat[Vr] 0;
+  #var combat[Vv] 0;
 
   #nop -- Combat buffs;
-  
+
+  #var combat[AA] 1;  
   #var combat[Bo] 1;
-  #var combat[Sj] 1;
-  #var combat[pf] 1;
   #var combat[CP] 1;
-  #var combat[pf] 1;
+  #var combat[pf] 0;
+  #var combat[Sj] 1;
 
   #nop -- Combat powers;
 
+  #var combat[bb] 0;
   #var combat[bc] 1;
-  #var combat[rpain] 1;
+  #var combat[BC] 0;
+  #var combat[dm] 1;
+  #var combat[ragony] 1;
+  #var combat[rpain] 0;
 };
 
-#alias {defense} {
-  #var psiwield 0;
-  #var psiwield_1 hammer;
+#alias {attack} {
+  #var psiwield 1;
+  #var psiwield_1 shard;
+  #var psiwield_2 shard 2;
+  #var use_expertise 0;
   #var combat {};
 
   #nop -- Defense buffs;
@@ -73,48 +88,29 @@
   #var combat[Vr] 0;
   #var combat[Eb] 0;
   #var combat[Cp] 0;
-  #var combat[Iv] 1;
-  #var combat[IV] 1;
-  #var combat[Ib] 1;
-  #var combat[IB] 1;
+  #var combat[Iv] 0;
+  #var combat[IV] 0;
+  #var combat[Ib] 0;
+  #var combat[IB] 0;
   #var combat[Vg] 1;
   #var combat[Vv] 0;
-  #var combat[ab] 1;
+  #var combat[ab] 0;
 
   #nop -- Combat buffs;
 
+  #var combat[AA] 1;
+  #var combat[Ac4] 0;
+  #var combat[Bo] 1;
+  #var combat[Cg] 0;
+  #var combat[CP] 1;
   #var combat[Sj] 1;
-  #var combat[Bo] 1;
-  #var combat[CP] 1;
-  #var combat[pf] 0;
-
-  #nop -- Combat powers;
-
-  #var combat[bb] 0;
-  #var combat[bc] 1;
-  #var combat[dm] 1;
-  #var combat[rpain] 1;
-};
-
-#alias {attack} {
-  #var psiwield 0;
-  #var combat {};
-
-  #nop -- Defense buffs;
-
-  #var combat[Vv] 1;
-
-  #nop -- Combat buffs;
-  
-  #var combat[Bo] 1;
-  #var combat[CP] 1;
-  #var combat[Ij] 1;
   #var combat[pf] 1;
 
   #nop -- Combat powers;
-  
-  #var combat[bb] 0;
-  #var combat[bc] 1;
-  #var combat[dm] 1;
-  #var combat[rpain] 1;
+
+  #var combat[bc] 0;
+  #var combat[BC] 1;
+  #var combat[E] 1;
+  #var combat[ragony] 1;
+  #var combat[rpain] 0;
 };

--- a/chars/droptable/aliases.tin
+++ b/chars/droptable/aliases.tin
@@ -90,7 +90,9 @@
 
   #nop -- Combat powers;
 
+  #var combat[bb] 0;
   #var combat[bc] 1;
+  #var combat[dm] 1;
   #var combat[rpain] 1;
 };
 
@@ -111,6 +113,8 @@
 
   #nop -- Combat powers;
   
+  #var combat[bb] 0;
   #var combat[bc] 1;
+  #var combat[dm] 1;
   #var combat[rpain] 1;
 };

--- a/chars/droptable/droptable.tin
+++ b/chars/droptable/droptable.tin
@@ -38,5 +38,4 @@
 #substitute {-R-_} {};
 #prompt {^>$} {>} {0};
 
-base;
 defense;

--- a/common/guilds/psicorps/README.md
+++ b/common/guilds/psicorps/README.md
@@ -85,8 +85,24 @@ Here's an example of a defense setup:
 
 It is recommended to create a default power set and run this as part your character's tintin++ initialization so that a set of powers is always present.
 
-## Adapt body
+## Specific powers
+
+### Adapt body
 
 If you add `exa mob` to your pre fight check, it will store the best damage type to use for adapt body. You'll need the right mskill that shows you the mobs damage type first. Then when starting the fight it will change adapt body to use the right damage type if it isn't already.
 
 Make sure to add adapt body to your power configuration with `addp ab`.
+
+### Demoralize, brilliant blast
+
+These are used once per fight at the start. For brilliant blast, it'll only do it if it's considered a safe arae. For now that's chessboard, but feel free to modify as you see fit. Eventually, we can add some code around checking number of targets or expand the logic.
+
+If you have both demoralize and brilliant blast, it'll try to chain them in one round.
+
+Make sure to add them to your power configuration: `addp dm]` and `addp bb`
+Or better yet add them to your power aliases with `#var combat[dm] 1` and `#var combat[bb] 1`.
+
+### Greater mindlink
+
+Add your greater mind link target to the heartbeat file `greater_mind_link_target` and `addp ML`
+

--- a/common/guilds/psicorps/README.md
+++ b/common/guilds/psicorps/README.md
@@ -99,10 +99,9 @@ These are used once per fight at the start. For brilliant blast, it'll only do i
 
 If you have both demoralize and brilliant blast, it'll try to chain them in one round.
 
-Make sure to add them to your power configuration: `addp dm]` and `addp bb`
+Make sure to add them to your power configuration: `addp dm` and `addp bb`
 Or better yet add them to your power aliases with `#var combat[dm] 1` and `#var combat[bb] 1`.
 
 ### Greater mindlink
 
 Add your greater mind link target to the heartbeat file `greater_mind_link_target` and `addp ML`
-

--- a/common/guilds/psicorps/README.md
+++ b/common/guilds/psicorps/README.md
@@ -102,6 +102,8 @@ If you have both demoralize and brilliant blast, it'll try to chain them in one 
 Make sure to add them to your power configuration: `addp dm]` and `addp bb`
 Or better yet add them to your power aliases with `#var combat[dm] 1` and `#var combat[bb] 1`.
 
+Also make sure to reset the `_dm` and `_bb` variables to 0 before starting a fight so that the script knows to try to use them. A good place to do that is in the `.pre_fight_check` alias.
+
 ### Greater mindlink
 
 Add your greater mind link target to the heartbeat file `greater_mind_link_target` and `addp ML`

--- a/common/guilds/psicorps/actions.tin
+++ b/common/guilds/psicorps/actions.tin
@@ -21,7 +21,7 @@
 
 #act {^Implant: Shutdown complete.} {#var my[powers] = []};
 
-#NOP ---- Damage types for adapt body
+#NOP ---- Damage type
 
 #act {^%1 melee attacks do %2 damage.$} {
 	#regex {%2} {{(mostly )?slashing}} {#var _adapt_body edged};
@@ -35,5 +35,11 @@
 	#regex {%2} {{(mostly )?poison}} {#var _adapt_body poison};
 	#regex {%2} {{(mostly )?radiation}}	{#var _adapt_body radiation}; 
 };
+
+#NOP ---- Offense
+
+#act {^You agitate the molecules in the air into a blast of brilliant light} {#var _bb 1};
+#act {^You demoralize} {#var _dm 1};
+#act {^That target cannot be re-demoralized.} {#var _dm 1};
 
 #class {psicorps_actions} {close}

--- a/common/guilds/psicorps/aliases.tin
+++ b/common/guilds/psicorps/aliases.tin
@@ -3,8 +3,6 @@
 
 #NOP --- PSICORPS ALIASES
 
-#NOP ---- Power management
-
 #alias {addp} {
   #var combat[%1] 1;
 };
@@ -37,6 +35,7 @@
   @show_power{Bf;biofeedback};
   @show_power{Cp;combat precognition};
   @show_power{D;dodge};
+  @show_power{Di;displacement};
   @show_power{Eb;energy barrier};
   @show_power{Ib;inertial barrier};
   @show_power{IB;improved biofeedback};
@@ -52,6 +51,7 @@
   
   @show_power{Bo;bolt};
   @show_power{CP;combat prescience};
+  @show_power{Cg;conductive grasp};
   @show_power{E;expertise};
   @show_power{Ij;iron jaw};
   @show_power{Sj;steel jaw};
@@ -65,9 +65,16 @@
   @show_power{Ac4;astral construct 4};
   @show_power{Ac5;astral construct 5};
   @show_power{bc;biocurrent};
+  @show_power{BC;greater biocurrent};
   @show_power{CG;conductive grasp};
   @show_power{rpain;recall pain};
   @show_power{ragony;recall agony};
+
+  #showme ----------------;
+  #showme ---  Group   ---;
+  #showme ----------------;
+
+  @show_power{ML;greater mindlink $greater_mind_link_target};
 
   #showme ----------------;
 };

--- a/common/guilds/psicorps/heartbeat.tin
+++ b/common/guilds/psicorps/heartbeat.tin
@@ -1,9 +1,13 @@
 #class {psicorps_heartbeat} {kill}
 #class {psicorps_heartbeat} {open}
 
+#var greater_mind_link_target none;
 #var use_body_fuel 1;
 #var use_chain 1;
+#var use_convert 1;
 #var _adapt_body edged;
+#var _bb 0;
+#var _dm 0;
 #var current_adapt_body none;
 #var hbp 0; /* has a heartbeat power been used this heartbeat */
 #var power_override none; /* if not equal to "none", uses this power immediately once */
@@ -66,7 +70,7 @@
         #if {$_DEBUG_HB} {#show [debug_heartbeat] changing adapt body dmg type to $_adapt_body};
         @use_adapt_body{};
         #return #nop;
-      }
+      };
       #else {
         #return #nop
       };
@@ -124,14 +128,9 @@
       #SHOW [debug_heartbeat] GP1: $my[gp1][current]/$my[gp1][max];
       #SHOW [debug_heartbeat] GP2: $my[gp2][current]/$my[gp2][max];
     };
-
-    #delay {0.1} {
-      _guild_heartbeat;
-      _player_heartbeat;
-    };
 };
 
-#act {^[[%*]]} {
+#act {^[[ %* ]]} {
     #var powers %1;
     #replace powers {:}{};
     #replace powers { }{;};
@@ -169,6 +168,11 @@
         #var my[powers_time][$power] $time;
         #math {i} {$i + 2};
     };
+
+    #delay {0.1} {
+      _guild_heartbeat;
+      _player_heartbeat;
+    };
 };
 
 #alias {_guild_heartbeat} {
@@ -197,6 +201,10 @@
     @use_power{body adjustment};
   };
 
+  #nop -- Group powers;
+
+  @check_power{ML;greater mindlink $greater_mind_link_target};
+
   #nop -- Defense;
 
   @check_power{AA;animal affinity bull};
@@ -204,6 +212,7 @@
   @check_power{Bf;biofeedback};
   @check_power{Cp;combat precognition};
   @check_power{D;dodge};
+  @check_power{Di;displacement};
   @check_power{Eb;energy barrier};
   @check_power{Ib;inertial barrier};
   @check_power{IB;improved biofeedback};
@@ -217,6 +226,7 @@
   
   @check_power{Bo;bolt};
   @check_power{CP;combat prescience};
+  @check_power{Cg;conductive grasp};
   @check_power{E;expertise};
   @check_power{Ij;iron jaw};
   @check_power{Sj;steel jaw};
@@ -227,14 +237,34 @@
   @check_power{Ac4;astral construct 4};
   @check_power{Ac5;astral construct 5};
   @check_power{bc;biocurrent};
+  @check_power{BC;greater biocurrent};
   @check_power{CG;conductive grasp};
+
+  #nop --- One offs;
+
+  #if {!$hbp} {
+    #var safe_aoe 0;
+    #if {"$area" == "Chessboard"} {
+      #var safe_aoe 1;
+    };
+
+    #if {$combat[bb] && $combat[dm] && !$_bb && $safe_aoe} {
+      @use_power{chain brilliant blast, demoralize};
+    };
+    #elseif {$combat[bb] && !$_bb && $safe_aoe} {
+      @use_power{brilliant blast};
+    };
+    #elseif {$combat[dm] && !$_dm} {
+      @use_power{demoralize};
+    };
+  };
 
   #nop --- Recall pain;
 
   #if {$combat[rpain]} {
     #if {!$hbp} {
       #math {gp1_percent} {$my[gp1][current] / $my[gp1][max] * 100.0};
-      #if {$gp1_percent > 80.0} {
+      #if {$gp1_percent > 20.0} {
         #if {$rpain_cnt == 0} {
           @use_power{recall pain};
           #math {rpain_cnt} {$rpain_cnt + 1};
@@ -249,10 +279,10 @@
   #if {$combat[ragony]} {
     #if {!$hbp} {
       #math {gp1_percent} {$my[gp1][current] / $my[gp1][max] * 100.0};
-      #if {$gp1_percent > 80.0} {
+      #if {$gp1_percent > 20.0} {
         #if {$ragony_cnt == 0} {
           @use_power{recall agony};
-          #math {ragony_cnt} {$ragony_cnt + 5};
+          #math {ragony_cnt} {$ragony_cnt + 4};
         };
         #else {
           #math {ragony_cnt} {$ragony_cnt - 1};
@@ -285,7 +315,7 @@
 
     #nop -- Pick GP1 heal power;
 
-    #if {$my[sp][current] / $my[sp][max] > 0.99 && $psi_missing >= $my[sp][max] * $sp_to_psi_ratio} {
+    #if {$my[sp][current] / $my[sp][max] > 0.99 && $psi_missing >= $my[sp][max] * $sp_to_psi_ratio && $use_convert} {
       @use_power{convert};
     };
     #elseif {$can_safely_use_body_fuel && $use_body_fuel} {


### PR DESCRIPTION
Lifts in some changes from my local psicorps setup.

## New powers supported

* Brilliant blast
* Demoralize
* Greater mindlink

## Fixes

* Fixes `recall agony` timer to not waste a round.
* Can now skip converting if you want via `use_convert` var (if you're greater mindlinking someone, for example)
* Fixes the hpbar power reader to ignore things like connection messages (`[[Soandso Disconnects]]` used to trigger it, heh)